### PR TITLE
Add missing string 'never'

### DIFF
--- a/templates/log.mustache
+++ b/templates/log.mustache
@@ -59,7 +59,7 @@
                         ({{#userdate}} {{lastcheck.absolute}}, {{#str}} strftimedatetime, core_langconfig {{/str}} {{/userdate}})
                     {{/lastcheck}}
                     {{^lastcheck}}
-                        {{#str}} never, tool_userautodelete {{/str}}
+                        {{#str}} never {{/str}}
                     {{/lastcheck}}
                 </td>
             </tr>


### PR DESCRIPTION
It seems that [the templates/log.mustache file](https://github.com/ngandrass/moodle-tool_userautodelete/blob/1e4740e314c0e8f62cd3be472b89371b144d352b/templates/log.mustache#L62) uses the string with the ID '**never**', but this string is not present in the lang files.

This PR should resolve this issue.

Thank you,
