### PR TITLE
Feature: Allow PHP-backed filtering of users by ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Create a cohort action that allows to add or remove users to / from one or more cohorts. See [Action: Cohort Membership](https://moodleuserlifecycle.gandrass.de/actions/cohort/) for more information.
 - Create a user profile field action that allows to set a user profile field to a configured value. See [Action: Set Profile Field](https://moodleuserlifecycle.gandrass.de/actions/profilefield/) for more information.
 - Extend mail action to support different recipient types: targeted user (previously fixed behavior), site administrators, custom email address
+- Allow filter sub-plugins to define custom PHP-backed filter logic, allowing sophisticated checks against APIs, files, or other data sources outside of the Moodle database. See [Post-filtering](https://moodleuserlifecycle.gandrass.de/dev/createfilter/#post-filtering) for more information.
 
 
 ## Version 2.3.0 (2026072200)

--- a/classes/local/util/plugin_util.php
+++ b/classes/local/util/plugin_util.php
@@ -46,6 +46,14 @@ class plugin_util {
     public static function get_subplugin_class(string $plugintype, string $pluginname): string {
         global $CFG;
 
+        // During unit tests allow fixture classes that are loaded by the test case but are not formally installed.
+        if (defined('PHPUNIT_TEST') && PHPUNIT_TEST) {
+            $plugincls = "\\{$plugintype}_{$pluginname}\\{$plugintype}";
+            if (class_exists($plugincls)) {
+                return $plugincls;
+            }
+        }
+
         // During upgrades do not expect plugins to be enabled and fully installed.
         // This case is required when migrating existing settings into new sub-plugins in one go.
         if (isset($CFG->upgraderunning) || during_initial_install()) {

--- a/classes/step.php
+++ b/classes/step.php
@@ -575,4 +575,26 @@ class step {
             params: $filterparams
         );
     }
+
+    /**
+     * Applies all post-filters to the given list of user IDs.
+     *
+     * Calls user_records_postfilter() on each filter linked to this step,
+     * progressively narrowing the candidate list. Stops early if the list
+     * becomes empty.
+     *
+     * @param int[] $userids Candidate user IDs to filter.
+     * @return int[] Subset of $userids that pass all post-filters.
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function apply_user_postfilters(array $userids): array {
+        foreach ($this->get_filters() as $filter) {
+            if (empty($userids)) {
+                break;
+            }
+            $userids = $filter->user_records_postfilter($userids);
+        }
+        return $userids;
+    }
 }

--- a/classes/userdeletefilter.php
+++ b/classes/userdeletefilter.php
@@ -166,4 +166,22 @@ abstract class userdeletefilter extends step_subplugin {
      * @return userfilter_clause The SQL where clause and parameters for filtering user datasets
      */
     abstract public function user_records_filter_clause(): userfilter_clause;
+
+    /**
+     * Optionally post-filters a pre-selected set of user IDs using arbitrary PHP logic.
+     *
+     * ATTENTION: Use this function very sparingly. Always implement as much filtering
+     * as possible inside user_records_filter_clause() for performance reasons!
+     *
+     * Override this to perform checks that cannot be expressed as SQL (e.g., remote
+     * API calls, complex aggregations). Called only after user_records_filter_clause()
+     * has already narrowed the candidate set. Receives all surviving IDs in one batch
+     * so implementations can minimize round-trips.
+     *
+     * @param int[] $userids Candidate user IDs that passed the SQL filter stage.
+     * @return int[] Subset of $userids that also pass this filter.
+     */
+    public function user_records_postfilter(array $userids): array {
+        return $userids;
+    }
 }

--- a/classes/workflow.php
+++ b/classes/workflow.php
@@ -533,7 +533,18 @@ class workflow {
             $processes = process::get_active_processes_for_step($step, transitionableonly: true);
             $targetstep = $step->next();
             if (empty($processes) || !$targetstep) {
-                logger::info("  -> No transitionable processes found");
+                logger::info("  -> No transitionable processes found after SQL-filtering");
+                continue;
+            }
+
+            // Apply post-filters from the target step.
+            $filtereduserids = array_flip($targetstep->apply_user_postfilters(
+                array_map(fn($p) => $p->userid, $processes)
+            ));
+            $processes = array_filter($processes, fn($p) => isset($filtereduserids[$p->userid]));
+
+            if (empty($processes)) {
+                logger::info('  -> No transitionable processes found after post-filtering');
                 continue;
             }
 
@@ -649,11 +660,12 @@ class workflow {
     protected function get_applicable_users(): array {
         global $DB;
 
-        $userfilterclause = $this->get_steps()[0]->generate_user_filter_clause();
+        $firststep = $this->get_steps()[0];
+        $userfilterclause = $firststep->generate_user_filter_clause();
 
         // Get all users this workflow is sensitive to and that are not yet part
         // of any other workflow.
-        return $DB->get_fieldset_sql(
+        $userids = $DB->get_fieldset_sql(
             'SELECT u.id
             FROM {user} u
             WHERE u.deleted = 0
@@ -668,6 +680,8 @@ class workflow {
                 $userfilterclause->params
             )
         );
+
+        return $firststep->apply_user_postfilters($userids);
     }
 
     /**

--- a/docs/dev/createfilter.md
+++ b/docs/dev/createfilter.md
@@ -2,9 +2,14 @@
 
 Filters are used to select the Moodle users that are eligible to enter or transition between
 [workflow steps](../workflow/steps.md). Each filter contributes a SQL `WHERE` clause fragment that is combined with
-all other active filters via a logical `AND` to produce the final user selection query.
+all other active filters via a logical `AND` to produce the final user selection query. An additional PHP-based 
+post-filtering stage is available for use cases that cannot be expressed in SQL.
 
 Filters are implemented as small subplugins and can therefore be easily extended by your own institution-specific filters.
+
+!!! example "Example filter subplugin implementations"
+    You can find many examples of filter subplugins directly within {{ source_file('filter/') }}.
+
 
 ## Overview
 
@@ -46,6 +51,7 @@ classDiagram
         +get_plugin_name()$ string
         +instance_setting_descriptors()$ array
         +user_records_filter_clause() userfilter_clause
+        +user_records_postfilter(userids: int[]) int[]
     }
 
     %% Supporting classes
@@ -81,36 +87,59 @@ classDiagram
 
 </div>
 
+!!! warning "PHPDocs are the ground source of truth"
+    Please refer to the PHPDocs in the source code as the ground source of truth for detailed
+    information regarding the implementation of these methods and their expected behavior.
+
 
 ## Implementation
 
 All filter subplugins must use the `userdeletefilter` frankenstyle plugin type and extend the abstract
 {{ source_file('classes/userdeletefilter.php', '\\tool_userautodelete\\userdeletefilter') }} base class.
 
-Any filter subplugin must implement the following methods:
+Filtering is possible in two stages that are described in detail below:
+
+  - [SQL-based filtering](#sql-based-filtering) (preferred)
+  - [PHP-based post-filtering](#post-filtering)
+
+At a minimum, any filter subplugin must implement the following methods:
 
 1. {{ source_file('classes/step_subplugin.php', 'get_plugin_name(): string') }}
 2. {{ source_file('classes/userdeletefilter.php', 'user_records_filter_clause(): userfilter_clause') }}
 3. {{ source_file('classes/local/trait/subplugin_instance_settings.php', 'instance_setting_descriptors(): array') }}
    (see also: [instance settings](instancesettings.md))
 
-The `user_records_filter_clause()` method must return a
-{{ source_file('classes/local/type/userfilter_clause.php', 'userfilter_clause') }} object that contains
-a SQL `WHERE` clause fragment and the associated named parameters. All references to user table columns
-**must** use the `u` table alias (e.g., `u.lastaccess`). All active filter clauses are joined with a SQL
-`AND` operator at the time of evaluation.
-
-You do not have to prefix your SQL parameter names in any way, as the core plugin will automatically
-prefix them uniquely for you at the time of evaluation.
-
 Of course you can also override other methods like {{ source_file('classes/step_subplugin.php',
 'get_instance_details(): string') }} or {{ source_file('classes/userdeletefilter.php',
 'get_icon_class(): string') }} to further customize the behavior of your filter subplugin and how it
 displays within the UI.
 
-!!! warning "PHPDocs are the ground source of truth"
-    Please refer to the PHPDocs in the source code as the ground source of truth for detailed
-    information regarding the implementation of these methods and their expected behavior.
+### SQL-based filtering
 
-!!! example "Example filter subplugin implementations"
-    You can find many examples of filter subplugins directly within {{ source_file('filter/') }}.
+Every filter **must** implement `user_records_filter_clause()` to select target users from the Moodle database. The
+`user_records_filter_clause()` method must return a
+{{ source_file('classes/local/type/userfilter_clause.php', 'userfilter_clause') }} object that contains a SQL `WHERE`
+clause fragment and the associated named parameters. All references to user table columns **must** use the `u` table
+alias (e.g., `u.lastaccess`). All active filter clauses are joined with a SQL `AND` operator at the time of evaluation.
+
+!!! info "SQL parameter names are automatically prefixed"
+    You do not have to prefix your SQL parameter names in any way, as the core plugin will automatically
+    prefix them uniquely for you at the time of evaluation.
+
+### Post-filtering
+
+For use cases that cannot be expressed as SQL, such as remote API lookups, multi-system aggregations, or any logic that
+depends on data outside the Moodle database, filters can **optionally** implement a second, PHP-based stage by
+overriding `user_records_postfilter()`.
+
+This method is called **after** `user_records_filter_clause()` has already narrowed the candidate set. It receives all
+surviving user IDs in a single batch, so implementations can perform efficient bulk lookups instead of one call per
+user. Return the subset of `$userids` that passes this filter.
+
+By default, the `user_records_postfilter()` method returns the input unchanged so that the filter has no effect unless
+explicitly implemented.
+
+!!! danger "Prefer SQL filtering when possible"
+    The SQL stage runs as a single database query and scales well. Reserve
+    `user_records_postfilter()` for logic that genuinely cannot be expressed in SQL, since every
+    PHP-based check adds overhead proportional to the number of candidate users.

--- a/filter/confirmed/classes/privacy/provider.php
+++ b/filter/confirmed/classes/privacy/provider.php
@@ -26,6 +26,8 @@ namespace userdeletefilter_confirmed\privacy;
 
 /**
  * Privacy provider declaring that this plugin stores no personal data.
+ *
+ * @codeCoverageIgnore This is handled by Moodle core tests
  */
 class provider implements \core_privacy\local\metadata\null_provider {
     #[\Override]

--- a/tests/fixtures/filter_postfilterblock/userdeletefilter.php
+++ b/tests/fixtures/filter_postfilterblock/userdeletefilter.php
@@ -21,7 +21,6 @@
  * discovered by Moodle's plugin manager and therefore never installed in
  * production. It is loaded in unit tests via require_once.
  *
- * @package     userdeletefilter_postfilterblock
  * @copyright   2026 Niels Gandraß <niels@gandrass.de>
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/tests/fixtures/filter_postfilterblock/userdeletefilter.php
+++ b/tests/fixtures/filter_postfilterblock/userdeletefilter.php
@@ -21,6 +21,7 @@
  * discovered by Moodle's plugin manager and therefore never installed in
  * production. It is loaded in unit tests via require_once.
  *
+ * @package     tool_userautodelete
  * @copyright   2026 Niels Gandraß <niels@gandrass.de>
  * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/tests/fixtures/filter_postfilterblock/userdeletefilter.php
+++ b/tests/fixtures/filter_postfilterblock/userdeletefilter.php
@@ -1,0 +1,98 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Test-only filter fixture that blocks specific user IDs via post-filtering.
+ *
+ * This class is intentionally NOT placed inside filter/ so it is never
+ * discovered by Moodle's plugin manager and therefore never installed in
+ * production. It is loaded in unit tests via require_once.
+ *
+ * @package     userdeletefilter_postfilterblock
+ * @copyright   2026 Niels Gandraß <niels@gandrass.de>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace userdeletefilter_postfilterblock;
+
+use core\lang_string;
+use tool_userautodelete\local\type\instance_setting_descriptor;
+use tool_userautodelete\local\type\userfilter_clause;
+
+// phpcs:ignore
+defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
+
+
+/**
+ * Test fixture: passes all users through SQL but blocks specified IDs in post-filter.
+ */
+class userdeletefilter extends \tool_userautodelete\userdeletefilter {
+    /**
+     * Returns the short name of this sub-plugin.
+     *
+     * @return string Plugin name.
+     */
+    #[\Override]
+    public static function get_plugin_name(): string {
+        return 'postfilterblock';
+    }
+
+    /**
+     * Returns a pass-through SQL clause that matches all users.
+     *
+     * @return userfilter_clause SQL clause referencing the 'u' user table alias.
+     */
+    #[\Override]
+    public function user_records_filter_clause(): userfilter_clause {
+        return new userfilter_clause(sql: '1=1', params: []);
+    }
+
+    /**
+     * Removes any user IDs listed in the 'blockeduserids' instance setting.
+     *
+     * @param int[] $userids Candidate user IDs that passed the SQL filter stage.
+     * @return int[] Subset of $userids with blocked IDs removed.
+     */
+    #[\Override]
+    public function user_records_postfilter(array $userids): array {
+        $raw = $this->get_instance_setting('blockeduserids') ?? '';
+        if ($raw === '') {
+            return $userids;
+        }
+
+        $blocked = array_flip(array_map('intval', explode(',', $raw)));
+        return array_values(array_filter($userids, fn(int $id): bool => !isset($blocked[$id])));
+    }
+
+    /**
+     * Returns the instance setting descriptors for this filter.
+     *
+     * @return instance_setting_descriptor[] Array of setting descriptors.
+     * @throws \coding_exception
+     */
+    #[\Override]
+    public static function instance_setting_descriptors(): array {
+        return [
+            new instance_setting_descriptor(
+                key: 'blockeduserids',
+                title: new lang_string('filter', 'tool_userautodelete'),
+                type: PARAM_TEXT,
+                required: false,
+                default: '',
+            ),
+        ];
+    }
+}

--- a/tests/step_test.php
+++ b/tests/step_test.php
@@ -510,6 +510,65 @@ final class step_test extends \advanced_testcase {
     }
 
     /**
+     * Tests that apply_user_postfilters() returns the input unchanged when no filters are attached.
+     *
+     * @covers \tool_userautodelete\step
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_apply_user_postfilters_with_no_filters(): void {
+        $this->resetAfterTest();
+
+        $workflow = workflow::create('Test Workflow', 'Description');
+        $step = step::create(workflow: $workflow, title: 'Step', description: '');
+
+        $userids = [1, 2, 3];
+        $this->assertSame(
+            $userids,
+            $step->apply_user_postfilters($userids),
+            'A step with no filters must return user IDs unchanged.'
+        );
+    }
+
+    /**
+     * Tests that apply_user_postfilters() chains multiple post-filters in sequence.
+     *
+     * @covers \tool_userautodelete\step
+     *
+     * @return void
+     * @throws \ReflectionException
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_apply_user_postfilters_chains_multiple_filters(): void {
+        $this->resetAfterTest();
+
+        $workflow = workflow::create('Test Workflow', 'Description');
+        $step = step::create(workflow: $workflow, title: 'Step', description: '');
+
+        // First mock: keeps only IDs <= 10.
+        $filter1 = $this->createMock(userdeletefilter::class);
+        $filter1->method('user_records_postfilter')
+            ->willReturnCallback(fn($ids) => array_values(array_filter($ids, fn($id) => $id <= 10)));
+
+        // Second mock: keeps only even IDs.
+        $filter2 = $this->createMock(userdeletefilter::class);
+        $filter2->method('user_records_postfilter')
+            ->willReturnCallback(fn($ids) => array_values(array_filter($ids, fn($id) => $id % 2 === 0)));
+
+        $reflectionproperty = new \ReflectionProperty($step, 'filters');
+        $reflectionproperty->setValue($step, [$filter1, $filter2]);
+
+        $this->assertSame(
+            [2, 8],
+            $step->apply_user_postfilters([2, 5, 8, 11, 12]),
+            'Filters must be applied in sequence; result must be the intersection of both constraints.'
+        );
+    }
+
+    /**
      * Tests timeout determination based on next-step delay filters.
      *
      * @covers \tool_userautodelete\step

--- a/tests/userdeletefilter_testcase.php
+++ b/tests/userdeletefilter_testcase.php
@@ -330,4 +330,46 @@ abstract class userdeletefilter_testcase extends \advanced_testcase {
             'Filter record must be removed from the database after delete()'
         );
     }
+
+    /**
+     * Tests that user_records_postfilter() executes without error.
+     *
+     * Actual functional tests must be provided by the specific implementations themselves.
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_user_records_postfilter_executes_with_users(): void {
+        $this->resetAfterTest();
+
+        $step = $this->create_step();
+        $filter = $this->create_valid_filter_instance($step);
+
+        $user1 = $this->getDataGenerator()->create_user();
+        $user2 = $this->getDataGenerator()->create_user();
+        $user3 = $this->getDataGenerator()->create_user();
+
+        // At this point we simply check that the postfilter hook can be called without throwing an exception.
+        $filter->user_records_postfilter([$user1->id, $user2->id, $user3->id]);
+    }
+
+    /**
+     * Tests that user_records_postfilter() executes without error when given an
+     * emtpy userid list.
+     *
+     * Actual functional tests must be provided by the specific implementations themselves.
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_user_records_postfilter_executes_with_empty_list(): void {
+        $this->resetAfterTest();
+
+        $step = $this->create_step();
+        $filter = $this->create_valid_filter_instance($step);
+
+        $filter->user_records_postfilter([]);
+    }
 }

--- a/tests/workflow_test.php
+++ b/tests/workflow_test.php
@@ -924,15 +924,31 @@ final class workflow_test extends \advanced_testcase {
     }
 
     /**
+     * Provides data for post-filter tests.
+     *
+     * @return array<string, array<bool>> Data sets for the test.
+     */
+    public static function provide_withsurvivors_flag(): array {
+        return [
+            "with survivors" => [true],
+            "without survivors" => [false],
+        ];
+    }
+
+    /**
      * Tests that workflow::process() applies user_records_postfilter() during user ingestion.
      *
      * @covers \tool_userautodelete\workflow
+     * @dataProvider provide_withsurvivors_flag
      *
+     * @param bool $withsurvivors If true, post-filter will be setup to allow some users to survive.
+     * If false, all users will be rejected by the post-filter.
      * @return void
+     * @throws \coding_exception
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function test_process_applies_postfilter_during_ingestion(): void {
+    public function test_process_applies_postfilter_during_ingestion(bool $withsurvivors): void {
         require_once(__DIR__ . '/fixtures/filter_postfilterblock/userdeletefilter.php');
 
         $this->resetAfterTest();
@@ -947,21 +963,36 @@ final class workflow_test extends \advanced_testcase {
         $user3 = $this->getDataGenerator()->create_user(['suspended' => 1]);
 
         // Add postfilterblock filter that blocks user3 from being ingested.
-        userdeletefilter::create_instance($firststep, 'postfilterblock', ['blockeduserids' => (string) $user3->id]);
+        userdeletefilter::create_instance($firststep, 'postfilterblock', [
+            'blockeduserids' => $withsurvivors
+                ? "{$user3->id}"
+                : "{$user1->id},{$user2->id},{$user3->id}",
+        ]);
 
         $workflow->process();
 
         // Single-step workflows finish processes immediately on creation, so includefinished is required.
-        $this->assertCount(
-            1,
-            process::get_user_processes((int) $user1->id, includefinished: true),
-            'User 1 should be ingested into the workflow'
-        );
-        $this->assertCount(
-            1,
-            process::get_user_processes((int) $user2->id, includefinished: true),
-            'User 2 should be ingested into the workflow'
-        );
+        if ($withsurvivors) {
+            $this->assertCount(
+                1,
+                process::get_user_processes((int) $user1->id, includefinished: true),
+                'User 1 should be ingested into the workflow'
+            );
+            $this->assertCount(
+                1,
+                process::get_user_processes((int) $user2->id, includefinished: true),
+                'User 2 should be ingested into the workflow'
+            );
+        } else {
+            $this->assertEmpty(
+                process::get_user_processes((int) $user1->id, includefinished: true),
+                'User 1 must not be ingested because the post-filter blocks them'
+            );
+            $this->assertEmpty(
+                process::get_user_processes((int) $user2->id, includefinished: true),
+                'User 2 must not be ingested because the post-filter blocks them'
+            );
+        }
         $this->assertEmpty(
             process::get_user_processes((int) $user3->id, includefinished: true),
             'User 3 must not be ingested because the post-filter blocks them'
@@ -972,12 +1003,15 @@ final class workflow_test extends \advanced_testcase {
      * Tests that workflow::process() does not transition a user rejected by user_records_postfilter().
      *
      * @covers \tool_userautodelete\workflow
+     * @dataProvider provide_withsurvivors_flag
      *
+     * @param bool $withsurvivors If true, post-filter will be setup to allow some users to survive.
+     * If false, all users will be rejected by the post-filter.
      * @return void
      * @throws \dml_exception
      * @throws \moodle_exception
      */
-    public function test_process_does_not_transition_user_rejected_by_postfilter(): void {
+    public function test_process_does_not_transition_user_rejected_by_postfilter(bool $withsurvivors): void {
         global $DB;
         require_once(__DIR__ . '/fixtures/filter_postfilterblock/userdeletefilter.php');
 
@@ -998,25 +1032,49 @@ final class workflow_test extends \advanced_testcase {
         $this->assertSame(process_state::ACTIVE, $process2->state, 'Fixture process 2 should be active in step 1');
 
         // Attach post-filter to step 2 that blocks user2 from transitioning.
-        userdeletefilter::create_instance($workflow->steps[1], 'postfilterblock', ['blockeduserids' => (string) $user2->id]);
+        userdeletefilter::create_instance($workflow->steps[1], 'postfilterblock', [
+            'blockeduserids' => $withsurvivors
+                ? "{$user2->id}"               // User 1 survives filter. User 1 is deleted.
+                : "{$user1->id},{$user2->id}", // User 1 and user 2 are blocked by the filter. Nothing is deleted.
+        ]);
 
-        // Process: user1 passes step-2 SQL + post-filter → deleted; user2 blocked by post-filter → stays in step 1.
         $workflow->process();
 
-        $this->assertSame(
-            1,
-            (int) $DB->get_field('user', 'deleted', ['id' => $user1->id]),
-            'User 1 must be deleted after transitioning through the final step'
-        );
+        if ($withsurvivors) {
+            // User 2 was blocked by post-filter, user 1 survided. So user 1 should advance to the deletion step.
+            $this->assertSame(
+                1,
+                (int) $DB->get_field('user', 'deleted', ['id' => $user1->id]),
+                'User 1 must be deleted after transitioning through the final step'
+            );
+            $this->assertSame(
+                process_state::FINISHED,
+                process::get_by_id($process1->id)->state,
+                'Process 1 must be finished after the final step'
+            );
+        } else {
+            $this->assertSame(
+                0,
+                (int) $DB->get_field('user', 'deleted', ['id' => $user1->id]),
+                'User 1 must not be deleted after transitioning through the final step'
+            );
+            $this->assertSame(
+                process_state::ACTIVE,
+                process::get_by_id($process1->id)->state,
+                'Process 1 must remain active because the post-filter blocked the transition'
+            );
+            $this->assertSame(
+                $workflow->steps[0]->id,
+                process::get_by_id($process1->id)->stepid,
+                'Process 1 must still be in step 1 after being rejected by the post-filter'
+            );
+        }
+
+        // User 2 is always blocked by the post-filter so should stay in any case.
         $this->assertSame(
             0,
             (int) $DB->get_field('user', 'deleted', ['id' => $user2->id]),
             'User 2 must not be deleted because the post-filter blocked the transition'
-        );
-        $this->assertSame(
-            process_state::FINISHED,
-            process::get_by_id($process1->id)->state,
-            'Process 1 must be finished after the final step'
         );
         $this->assertSame(
             process_state::ACTIVE,

--- a/tests/workflow_test.php
+++ b/tests/workflow_test.php
@@ -894,6 +894,143 @@ final class workflow_test extends \advanced_testcase {
     }
 
     /**
+     * Tests that get_applicable_users_count() respects user_records_postfilter().
+     *
+     * @covers \tool_userautodelete\workflow
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_get_applicable_users_count_respects_postfilter(): void {
+        require_once(__DIR__ . '/fixtures/filter_postfilterblock/userdeletefilter.php');
+
+        $this->resetAfterTest();
+
+        // Prepare inactive single-step workflow with a suspension SQL-filter.
+        $generator = $this->get_userautodelete_generator();
+        $workflow = $generator->create_simple_suspend_workflow('Workflow', 'Description', false);
+        $firststep = $workflow->steps[0];
+
+        $user1 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $user2 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $user3 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+
+        // Add postfilterblock filter that blocks user3.
+        userdeletefilter::create_instance($firststep, 'postfilterblock', ['blockeduserids' => (string) $user3->id]);
+
+        // All three pass SQL, but only two survive the post-filter.
+        $this->assertSame(2, $workflow->get_applicable_users_count(), 'Post-filter must reduce the applicable user count');
+    }
+
+    /**
+     * Tests that workflow::process() applies user_records_postfilter() during user ingestion.
+     *
+     * @covers \tool_userautodelete\workflow
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_process_applies_postfilter_during_ingestion(): void {
+        require_once(__DIR__ . '/fixtures/filter_postfilterblock/userdeletefilter.php');
+
+        $this->resetAfterTest();
+
+        // Prepare active single-step workflow with a suspension SQL-filter.
+        $generator = $this->get_userautodelete_generator();
+        $workflow = $generator->create_simple_suspend_workflow('Workflow', 'Description', true);
+        $firststep = $workflow->steps[0];
+
+        $user1 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $user2 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $user3 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+
+        // Add postfilterblock filter that blocks user3 from being ingested.
+        userdeletefilter::create_instance($firststep, 'postfilterblock', ['blockeduserids' => (string) $user3->id]);
+
+        $workflow->process();
+
+        // Single-step workflows finish processes immediately on creation, so includefinished is required.
+        $this->assertCount(
+            1,
+            process::get_user_processes((int) $user1->id, includefinished: true),
+            'User 1 should be ingested into the workflow'
+        );
+        $this->assertCount(
+            1,
+            process::get_user_processes((int) $user2->id, includefinished: true),
+            'User 2 should be ingested into the workflow'
+        );
+        $this->assertEmpty(
+            process::get_user_processes((int) $user3->id, includefinished: true),
+            'User 3 must not be ingested because the post-filter blocks them'
+        );
+    }
+
+    /**
+     * Tests that workflow::process() does not transition a user rejected by user_records_postfilter().
+     *
+     * @covers \tool_userautodelete\workflow
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_process_does_not_transition_user_rejected_by_postfilter(): void {
+        global $DB;
+        require_once(__DIR__ . '/fixtures/filter_postfilterblock/userdeletefilter.php');
+
+        $this->resetAfterTest();
+
+        // Prepare active two-step workflow: step 1 unsuspends, step 2 deletes (filter: suspended = 0).
+        $generator = $this->get_userautodelete_generator();
+        $workflow = $generator->create_multistep_suspend_delete_workflow('Workflow', 'Description', true);
+
+        // Create two suspended users and seed them into step 1 (the creation unsuspends them).
+        $user1 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $user2 = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $process1 = process::create((int) $user1->id, $workflow);
+        $process2 = process::create((int) $user2->id, $workflow);
+
+        // Both users are now unsuspended (step-1 action) and active in step 1.
+        $this->assertSame(process_state::ACTIVE, $process1->state, 'Fixture process 1 should be active in step 1');
+        $this->assertSame(process_state::ACTIVE, $process2->state, 'Fixture process 2 should be active in step 1');
+
+        // Attach post-filter to step 2 that blocks user2 from transitioning.
+        userdeletefilter::create_instance($workflow->steps[1], 'postfilterblock', ['blockeduserids' => (string) $user2->id]);
+
+        // Process: user1 passes step-2 SQL + post-filter → deleted; user2 blocked by post-filter → stays in step 1.
+        $workflow->process();
+
+        $this->assertSame(
+            1,
+            (int) $DB->get_field('user', 'deleted', ['id' => $user1->id]),
+            'User 1 must be deleted after transitioning through the final step'
+        );
+        $this->assertSame(
+            0,
+            (int) $DB->get_field('user', 'deleted', ['id' => $user2->id]),
+            'User 2 must not be deleted because the post-filter blocked the transition'
+        );
+        $this->assertSame(
+            process_state::FINISHED,
+            process::get_by_id($process1->id)->state,
+            'Process 1 must be finished after the final step'
+        );
+        $this->assertSame(
+            process_state::ACTIVE,
+            process::get_by_id($process2->id)->state,
+            'Process 2 must remain active because the post-filter blocked the transition'
+        );
+        $this->assertSame(
+            $workflow->steps[0]->id,
+            process::get_by_id($process2->id)->stepid,
+            'Process 2 must still be in step 1 after being rejected by the post-filter'
+        );
+    }
+
+    /**
      * Tests that cleanup_processes() is a no-op when no process timed out.
      *
      * @covers \tool_userautodelete\workflow


### PR DESCRIPTION
This PR addresses #18 by adding `user_records_postfilter(array $userids): array` to the `userdeletefilter` interface, allowing to filter a list of user IDs using arbitrary PHP logic. The dev docs page gives insight on how to use it.