### PR TITLE
Feature: Manually aborting user processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Create a account confirmation filter that allows to select users based on whether they have confirmed their account or not. See [Filter: Account Confirmation](https://moodleuserlifecycle.gandrass.de/filters/confirmed/) for more information.
 - Create a cohort action that allows to add or remove users to / from one or more cohorts. See [Action: Cohort Membership](https://moodleuserlifecycle.gandrass.de/actions/cohort/) for more information.
 - Create a user profile field action that allows to set a user profile field to a configured value. See [Action: Set Profile Field](https://moodleuserlifecycle.gandrass.de/actions/profilefield/) for more information.
-- Extend mail action to support different recipient types: targeted user (previously fixed behavior), site administrators, custom email address
+- Extend mail action to support different recipient types: targeted user (previously fixed behavior), site administrators, custom email address.
+- Add button to process inspection dialog that allows admins to abort specific user processes on demand.
 - Allow filter sub-plugins to define custom PHP-backed filter logic, allowing sophisticated checks against APIs, files, or other data sources outside of the Moodle database. See [Post-filtering](https://moodleuserlifecycle.gandrass.de/dev/createfilter/#post-filtering) for more information.
 
 

--- a/classes/external/get_step_user_processes.php
+++ b/classes/external/get_step_user_processes.php
@@ -74,6 +74,7 @@ class get_step_user_processes extends external_api {
                 'username'        => new external_value(PARAM_TEXT, 'Username'),
                 'fullname'        => new external_value(PARAM_TEXT, 'Full name of the user'),
                 'profileurl'      => new external_value(PARAM_URL, 'URL to the user\'s profile page'),
+                'aborturl'        => new external_value(PARAM_URL, 'URL to abort this process (empty if not active)'),
                 'isactive'        => new external_value(PARAM_BOOL, 'Whether the process is currently active'),
                 'isfinished'      => new external_value(PARAM_BOOL, 'Whether the process has finished successfully'),
                 'isaborted'       => new external_value(PARAM_BOOL, 'Whether the process was aborted'),
@@ -115,16 +116,26 @@ class get_step_user_processes extends external_api {
         $records = process::get_user_process_metadata_for_step($step, $activeonly);
 
         // Map DB records to the return structure.
+        $returnurl = (new \moodle_url('/admin/tool/userautodelete/workflow.php', ['id' => $step->workflow->id]))->out(false);
         $now = time();
         $result = [];
         foreach ($records as $record) {
             $state = process_state::from((int) $record->state);
+            $aborturl = $state === process_state::ACTIVE
+                ? (new \moodle_url('/admin/tool/userautodelete/manageprocess.php', [
+                    'id'        => (int) $record->id,
+                    'action'    => 'abort',
+                    'returnurl' => $returnurl,
+                ]))->out(false)
+                : '';
+
             $result[] = [
                 'processid'       => (int) $record->id,
                 'userid'          => (int) $record->userid,
                 'username'        => (string) $record->username,
                 'fullname'        => "{$record->firstname} {$record->lastname}",
                 'profileurl'      => (new \moodle_url('/user/profile.php', ['id' => $record->userid]))->out(false),
+                'aborturl'        => $aborturl,
                 'isactive'        => $state === process_state::ACTIVE,
                 'isfinished'      => $state === process_state::FINISHED,
                 'isaborted'       => $state === process_state::ABORTED,

--- a/classes/form/process_abort_form.php
+++ b/classes/form/process_abort_form.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines the process abort confirmation form.
+ *
+ * @package    tool_userautodelete
+ * @copyright  2026 Niels Gandraß <niels@gandrass.de>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_userautodelete\form;
+
+use tool_userautodelete\process;
+
+defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
+
+require_once("$CFG->libdir/formslib.php"); // @codeCoverageIgnore
+
+
+/**
+ * Form to confirm aborting a single user process.
+ */
+class process_abort_form extends \moodleform {
+    /**
+     * Form definition.
+     *
+     * @throws \dml_exception
+     * @throws \coding_exception
+     */
+    public function definition() {
+        global $OUTPUT;
+        $mform = $this->_form;
+
+        // Load process and affected user.
+        $process = process::get_by_id($this->optional_param('id', null, PARAM_INT));
+        $user = \core_user::get_user($process->userid, strictness: MUST_EXIST);
+
+        // Warning notification including the affected user's full name.
+        $warnhead = get_string('areyousure');
+        $warnmsg = get_string('abort_process_warning', 'tool_userautodelete', fullname($user) . " (ID: {$user->id})");
+
+        $mform->addElement('html', $OUTPUT->notification(
+            "<h4>$warnhead</h4> $warnmsg",
+            \core\output\notification::NOTIFY_WARNING,
+            false,
+        ));
+
+        // Preserve management page state across the form submission.
+        $mform->addElement('hidden', 'id', $this->optional_param('id', null, PARAM_INT));
+        $mform->setType('id', PARAM_INT);
+        $mform->addElement('hidden', 'action', $this->optional_param('action', null, PARAM_TEXT));
+        $mform->setType('action', PARAM_TEXT);
+        $mform->addElement('hidden', 'returnurl', $this->optional_param('returnurl', '', PARAM_LOCALURL));
+        $mform->setType('returnurl', PARAM_LOCALURL);
+
+        $this->add_action_buttons(true, get_string('abort_process', 'tool_userautodelete'));
+    }
+}

--- a/lang/de/tool_userautodelete.php
+++ b/lang/de/tool_userautodelete.php
@@ -28,7 +28,10 @@
 defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
 
 $string['a'] = '${a}';
+$string['abort_process'] = 'Prozess abbrechen';
+$string['abort_process_warning'] = 'Sie sind dabei, den aktiven Prozess für <b>{$a}</b> abzubrechen. Der Benutzer wird aus dem Workflow entfernt. Bei der nächsten geplanten Ausführung kann der Benutzer automatisch erneut aufgenommen werden, sofern er weiterhin den Filterkriterien des ersten Schritts entspricht. Sind Sie sicher, dass Sie fortfahren möchten?';
 $string['aborted'] = 'Abgebrochen';
+$string['cannot_abort_inactive_process'] = 'Ein nicht aktiver Prozess kann nicht abgebrochen werden.';
 $string['action'] = 'Aktion';
 $string['action_is_invalid'] = 'Diese Aktion ist aktuell ungültig und muss korrigiert werden, bevor der Workflow aktiviert werden kann.';
 $string['actions'] = 'Aktionen';

--- a/lang/en/tool_userautodelete.php
+++ b/lang/en/tool_userautodelete.php
@@ -28,7 +28,10 @@
 defined('MOODLE_INTERNAL') || die(); // @codeCoverageIgnore
 
 $string['a'] = '${a}';
+$string['abort_process'] = 'Abort process';
+$string['abort_process_warning'] = 'You are about to abort the active workflow process for <b>{$a}</b>. The user will be removed from the workflow. They may re-enter automatically on the next scheduled execution if they still match the first step\'s filters. Are you sure you want to continue?';
 $string['aborted'] = 'Aborted';
+$string['cannot_abort_inactive_process'] = 'Cannot abort a process that is not active.';
 $string['action'] = 'Action';
 $string['action_is_invalid'] = 'This action is currently invalid and must be fixed before the workflow can be enabled.';
 $string['actions'] = 'Actions';

--- a/manageprocess.php
+++ b/manageprocess.php
@@ -1,0 +1,85 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Collection of user process management operations.
+ *
+ * @package     tool_userautodelete
+ * @copyright   2026 Niels Gandraß <niels@gandrass.de>
+ * @license     https://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+use tool_userautodelete\form\process_abort_form;
+use tool_userautodelete\local\type\process_state;
+use tool_userautodelete\local\util\adminpage_util;
+use tool_userautodelete\process;
+
+require_once(__DIR__ . '/../../../config.php');
+require_once("{$CFG->libdir}/adminlib.php");
+
+global $CFG, $DB, $OUTPUT, $PAGE, $SITE, $USER;
+
+require_admin();
+
+// Request parameters.
+$processid = required_param('id', PARAM_INT);
+$returnurl = required_param('returnurl', PARAM_LOCALURL);
+$action = required_param('action', PARAM_ALPHA);
+
+// Setup page as sub-admin page of workflows overview.
+// This does not use admin_externalpage_setup as we do not want these detail
+// pages to be accessible via the default admin navigation tree since these
+// always require valid parameters.
+adminpage_util::admin_hidden_externalpage_setup(
+    section: 'tool_userautodelete_workflow',
+    title: get_string('manage_workflow', 'tool_userautodelete'),
+    url: new moodle_url('/admin/tool/userautodelete/manageprocess.php', [
+        'id' => $processid,
+        'action' => $action,
+    ]),
+    parentsection: 'tool_userautodelete_workflows'
+);
+
+$process = process::get_by_id($processid);
+
+// Handle actions.
+$output = '';
+if ($action == 'abort') {
+    if ($process->state !== process_state::ACTIVE) {
+        throw new moodle_exception('cannot_abort_inactive_process', 'tool_userautodelete');
+    }
+
+    $form = new process_abort_form();
+    if ($form->is_submitted()) {
+        if (!$form->is_cancelled()) {
+            $process->abort();
+        }
+    } else {
+        $output = $form->render();
+    }
+} else {
+    throw new moodle_exception('invalid_action', 'tool_userautodelete');
+}
+
+// Handle redirects.
+if (!$output) {
+    redirect(new moodle_url($returnurl));
+}
+
+// Output page if not redirected.
+echo $OUTPUT->header();
+echo $output;
+echo $OUTPUT->footer();

--- a/templates/modal/step_processes.mustache
+++ b/templates/modal/step_processes.mustache
@@ -44,7 +44,7 @@
 
 {{#hasprocesses}}
 <div class="table-responsive">
-    <table class="table table-sm table-hover mb-0">
+    <table class="table table-sm table-hover mb-0 border-top-0">
         <thead>
             <tr>
                 <th>{{#str}} id, tool_userautodelete {{/str}}</th>

--- a/templates/modal/step_processes.mustache
+++ b/templates/modal/step_processes.mustache
@@ -29,6 +29,7 @@
                 "username": "jdoe",
                 "fullname": "John Doe",
                 "profileurl": "https://mymoodle/user/profile.php?id=42",
+                "aborturl": "https://mymoodle/admin/tool/userautodelete/manageprocess.php?id=1&action=abort&returnurl=%2F...",
                 "isactive": true,
                 "isfinished": false,
                 "isaborted": false,
@@ -51,6 +52,7 @@
                 <th>{{#str}} lastaccess {{/str}}</th>
                 <th>{{#str}} state, tool_userautodelete {{/str}}</th>
                 <th>{{#str}} in_step_since, tool_userautodelete {{/str}}</th>
+                <th></th>
             </tr>
         </thead>
         <tbody>
@@ -96,6 +98,22 @@
                     >
                         {{timemodifiedrel}}
                     </span>
+                </td>
+                <td class="ps-2">
+                    {{#isactive}}
+                        <a
+                            href="{{{aborturl}}}"
+                            class="btn btn-sm btn-outline-danger"
+                            role="button"
+                            title="{{#str}} abort_process, tool_userautodelete {{/str}}"
+                            data-toggle="tooltip"
+                            data-title="{{#str}} abort_process, tool_userautodelete {{/str}}"
+                            data-bs-toggle="tooltip"
+                            data-bs-title="{{#str}} abort_process, tool_userautodelete {{/str}}"
+                        >
+                            <i class="fa-solid fa-ban fa-fw"></i>
+                        </a>
+                    {{/isactive}}
                 </td>
             </tr>
             {{/processes}}

--- a/templates/workflow.mustache
+++ b/templates/workflow.mustache
@@ -650,7 +650,6 @@
                             hasprocesses: processes.length > 0,
                         }),
                         isVerticallyCentered: true,
-                        // large: true,
                     });
 
                     modal.getModal().addClass('modal-xl');

--- a/templates/workflow.mustache
+++ b/templates/workflow.mustache
@@ -650,9 +650,10 @@
                             hasprocesses: processes.length > 0,
                         }),
                         isVerticallyCentered: true,
-                        large: true,
+                        // large: true,
                     });
 
+                    modal.getModal().addClass('modal-xl');
                     modal.show();
                 } catch (err) {
                     Notification.exception(err);

--- a/tests/form/process_abort_form_test.php
+++ b/tests/form/process_abort_form_test.php
@@ -1,0 +1,73 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Tests for the process_abort_form class
+ *
+ * @package   tool_userautodelete
+ * @copyright 2026 Niels Gandraß <niels@gandrass.de>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_userautodelete\form;
+
+use tool_userautodelete\process;
+
+/**
+ * Tests for the process_abort_form class
+ */
+final class process_abort_form_test extends \advanced_testcase {
+    /**
+     * Returns the plugin-specific test data generator.
+     *
+     * @return \tool_userautodelete_generator
+     */
+    private function get_userautodelete_generator(): \tool_userautodelete_generator {
+        /** @var \tool_userautodelete_generator $generator */
+        $generator = $this->getDataGenerator()->get_plugin_generator('tool_userautodelete');
+        return $generator;
+    }
+
+    /**
+     * Tests that the form definition path can be executed without errors.
+     *
+     * @covers \tool_userautodelete\form\process_abort_form
+     *
+     * @return void
+     * @throws \dml_exception
+     * @throws \moodle_exception
+     */
+    public function test_definition_runs(): void {
+        $this->resetAfterTest();
+        $this->setAdminUser();
+
+        // Create a workflow with an active process.
+        $generator = $this->get_userautodelete_generator();
+        $workflow = $generator->create_simple_suspend_workflow('Workflow', 'Description', true);
+        $step = $workflow->steps[0];
+        $user = $this->getDataGenerator()->create_user(['suspended' => 1]);
+        $process = process::create((int) $user->id, $workflow, $step);
+
+        $generator->prepare_form_environment('/admin/tool/userautodelete/manageprocess.php', [
+            'id'        => $process->id,
+            'action'    => 'abort',
+            'returnurl' => '/admin/tool/userautodelete/workflow.php?id=' . $workflow->id,
+        ]);
+
+        $form = new process_abort_form();
+        $this->assertInstanceOf(process_abort_form::class, $form, 'Form could not be instantiated');
+    }
+}


### PR DESCRIPTION
This PR adds a button to the admin UI that allows to abort specific user processes from the workflow step process overview modal dialog.